### PR TITLE
Scalyr Log Writter now includes an update now directive when we get o…

### DIFF
--- a/logging/scalyr.go
+++ b/logging/scalyr.go
@@ -39,7 +39,13 @@ func (w *ScalyrWriter) Write(p []byte) (int, error) {
 		w.buffer.Write(p)
 		w.lock.Unlock()
 	}
-	return w.tee.Write(p)
+	n, err := w.tee.Write(p)
+
+	if w.buffer.Len() > 2000000 {
+		w.UpdateNow()
+	}
+
+	return n, err
 }
 
 // CreateScalyrWriter will create an io.Writer which will tee all log writes


### PR DESCRIPTION
…ver 2m bytes long, as Scaylr has a 3m byte limit.